### PR TITLE
Trigger AI triage workflow on @ai-triage comment

### DIFF
--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -3,8 +3,8 @@
 
 name: AI Issue Triage
 on:
-  issues:
-    types: [opened]
+  issue_comment:
+    types: [created]
 
 permissions:
   issues: write
@@ -13,6 +13,7 @@ permissions:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    if: github.event.comment.body == '@ai-triage'
     steps:
       - name: Repository checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Change the AI issue triage workflow trigger from automatic execution on every new issue to manual execution via comment. The workflow now runs only when a comment containing exactly "@ai-triage" is posted on an issue.

## Summary
[short description of the problem and the change]: #



## Detailed description and/or reproducer
[Please be more descriptive yet concise here. This text will help us with testing, urgency and severity assessment.]: #
